### PR TITLE
change channel priorities and remove R channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,8 @@
 name: pipeline-template
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
-  - r
 dependencies:
   - pyyaml
   - biopet-sampleconfig==0.2


### PR DESCRIPTION
This is according to the guidelines posted by the bioconda team.
Removing the R channel makes dependency resolving a lot faster. Also
the R dependencies are mostly in defaults and conda-forge anyway.
Conda-forge is moved above bioconda according to the guidelines.